### PR TITLE
Remove paddlepaddle dep

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,4 +17,3 @@ attrdict
 Polygon3
 lanms-neo==1.0.2
 pdf2image
-paddlepaddle

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,6 @@ setup(
         "Polygon3",
         "lanms-neo==1.0.2",
         "pdf2image",
-        "paddlepaddle",
     ],
     license="Apache License 2.0",
     description="Awesome OCR toolkits based on PaddlePaddle （8.6M ultra-lightweight pre-trained model, support training and deployment among server, mobile, embeded and IoT devices",


### PR DESCRIPTION
We have created a custom wheel for aarch64 of paddlepaddle, however pypi requires a unique name of packages so we had to name it unstructured.paddlepaddle.  When it’s a dep for paddleocr it doesn’t work on aarch64.

We will take care of installing these packages in unstructured and unstructured-api in Dockerfiles and install scripts